### PR TITLE
Linux install error process.arch is not a function

### DIFF
--- a/link-binary.js
+++ b/link-binary.js
@@ -10,7 +10,7 @@ const debug = require('debug')('jqcw');
 const BinWrapper = require('bin-wrapper');
 const base = 'https://github.com/stedolan/jq/releases/download/jq-1.5';
 const platform = process.platform === 'darwin' ? 'osx' : 'linux';
-const arch = process.platform === 'darwin' ? 'amd64' : process.arch();
+const arch = process.platform === 'darwin' ? 'amd64' : process.arch;
 const jqExecutableName = `jq-${platform}-${arch}`;
 const bin = new BinWrapper()
   .src(`${base}/jq-osx-amd64`, 'darwin')


### PR DESCRIPTION
Fixes: #11 

On linux, the install fails w/ process.arch is not a function. This fixes that.

